### PR TITLE
Downgrades helm version to 2.9.1 -- supported by our clusters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM linkyard/docker-helm:2.10.0
+FROM linkyard/docker-helm:2.9.1
 LABEL maintainer "mario.siegenthaler@linkyard.ch"
 
 RUN apk add --update --upgrade --no-cache jq bash curl


### PR DESCRIPTION
After rebasing our repository on top of the upstream one (linkyard/concourse-helm-resource), I have pulled a change to upgrade helm to 2.10. However, it doesn't work with our cluster. See error below from Concourse:

```
resource script '/opt/resource/check []' failed: exit status 1

stderr:
Initializing kubectl...
Cluster "default" set.
User "admin" set.
Context "default" modified.
Switched to context "default".
Client Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.4", GitCommit:"5ca598b4ba5abb89bb773071ce452e33fb66339d", GitTreeState:"clean", BuildDate:"2018-06-06T08:13:03Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"8", GitVersion:"v1.8.7", GitCommit:"b30876a5539f09684ff9fde266fda10b37738c9c", GitTreeState:"clean", BuildDate:"2018-01-16T21:52:38Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}
Initializing helm...
Client: &version.Version{SemVer:"v2.10.0", GitCommit:"9ad53aac42165a5fadc6c87be0dea6b115f93090", GitTreeState:"clean"}
Server: &version.Version{SemVer:"v2.9.1", GitCommit:"20adb27c7c5868466912eebdf6664e7390ebe710", GitTreeState:"clean"}
Resource setup successful.
Error: incompatible versions client[v2.10.0] server[v2.9.1]
```

I'm downgrading it to 2.9.1.